### PR TITLE
Norms expert: remove plot_spectral functionality and replace with table

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 dependencies=[
     "footprints",
     "numpy",
-    "arpifs_listings>=1.2.1",
+    "arpifs_listings>=1.2.2",
     "taylorism",
     ]
 

--- a/src/ial_expertise/task.py
+++ b/src/ial_expertise/task.py
@@ -67,7 +67,7 @@ class TaskSummary(dict):
             out = open(out, 'w')
         else:
             close = False
-        json.dump(self, out, indent=4, sort_keys=True)
+        json.dump(self, out, indent=2, sort_keys=True)
         if close:
             out.close()
 


### PR DESCRIPTION
To make lighter the info transmitted to Ciboulai, which will do the plotting in the frontend from now on.